### PR TITLE
feat: Implement HTTP 1.1 Keep Alive

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -118,12 +118,15 @@ impl Response {
         for (key, value) in headers {
             res.push_str(&format!("{}: {}\r\n", key, value));
         }
+        res.push_str("Connection: keep-alive\r\n");
         res.push_str("Server: Blitzkrieg\r\n");
-        res.push_str("\r\n");
-        let mut res = res.as_bytes().to_owned();
         if let Some(mut body) = self.body {
+            res.push_str(&format!("Content-Length: {}\r\n", body.len()));
+            res.push_str("\r\n");
+            let mut res = res.as_bytes().to_owned();
             res.append(&mut body);
+            return res;
         }
-        res
+        res.as_bytes().to_owned()
     }
 }

--- a/src/http/parser.rs
+++ b/src/http/parser.rs
@@ -17,6 +17,9 @@ impl Request {
                 break;
             }
         }
+        if request.len() == 0 {
+            return Err("Reading returned nothing".into());
+        }
         let mut size = 0;
         let linesplit = request.split("\n");
         for l in linesplit {
@@ -40,6 +43,7 @@ impl Request {
     pub fn parse(request: String, body: Vec<u8>) -> Result<Request, String> {
         let request_lines: Vec<&str> = request.split("\r\n").collect();
         let mut first_line_iter = request_lines[0].split_whitespace();
+        println!("Incoming request: {}", request_lines[0]);
         let method = first_line_iter
             .next()
             .ok_or("Error while parsing HTTP method")?;
@@ -54,7 +58,7 @@ impl Request {
                 );
             }
         }
-        let default = "".to_string();
+        let default = String::new();
         let content_type = headers.get("Content-Type").unwrap_or(&default);
         if content_type.contains("multipart/form-data") {
             // This is because the line will have extra chars like " multipart/form-data; boundary=X-INSOMNIA-BOUNDARY"


### PR DESCRIPTION
Implement HTTP 1.1 Connection Keep Alive.
- https://datatracker.ietf.org/doc/html/rfc2068#section-19.7.1
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive